### PR TITLE
removed specdm checks and switched to IsActive()

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_mesdefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_mesdefi.lua
@@ -152,11 +152,11 @@ if SERVER then
       return
     end
 
-    if ply:Alive() and not (SpecDM and not ply:IsGhost()) then
-			self:Error(DEFI_ERROR_PLAYER_ALIVE)
+    if ply:IsActive() then
+      self:Error(DEFI_ERROR_PLAYER_ALIVE)
 
-			return
-		end
+      return
+    end
 
     local reviveTime = GetConVar("ttt2_mesdefi_revive_time"):GetFloat()
     -- local reviveTime = 3.0
@@ -190,11 +190,11 @@ if SERVER then
         SendFullStateUpdate()
       end,
       function(p)
-        if not IsValid(owner) or not owner:IsPlayer() or not owner:Alive() or owner:IsSpec() then
+        if not IsValid(owner) or not owner:IsPlayer() or not owner:IsActive() then
           self:CancelRevival()
           self:Error(DEFI_ERROR_FAILED)
           return false 
-        elseif not IsValid(p) or (p:Alive() and not (SpecDM and p:IsGhost())) then
+        elseif not IsValid(p) or p:IsActive() then
           self:CancelRevival()
           self:Error(DEFI_ERROR_FAILED)
           return false
@@ -258,7 +258,7 @@ if SERVER then
     elseif not owner:KeyDown(IN_ATTACK) or owner:GetEyeTrace(MASK_SHOT_HULL).Entity ~= self.defiTarget or owner:GetActiveWeapon():GetClass() ~= self:GetClass() then
       self:CancelRevival()
       self:Error(DEFI_ERROR_LOST_TARGET)
-    elseif target:Alive() and not (SpecDM and not target:IsGhost()) then
+    elseif target:IsActive() then
       self:CancelRevival()
       self:Error(DEFI_ERROR_PLAYER_ALIVE)
     end


### PR DESCRIPTION
I removed the specdm checks to resolve an issue which was reported in the Steam Workshop comment section:
`When reviving someone who is in spec dm from this addon https://steamcommunity.com/sharedfiles/filedetails/?id=1997666028 it says you can't revive them because they are already alive`

Now player can revive people from SpecDM too without being confused on why they can't revive a dead player.

The Alive() checks were switched to IsActive() which is more robust. (Checks if the player is in TEAM_TERROR (meaning alive and not spectating) and if the player is in an active round.)